### PR TITLE
Merging in Loreq's painting / performance changes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -67,11 +67,19 @@
         "PickIconTT": "Open Filebrowser to select an image"
       },
       "TERRAINSELECTOR": {
-        "Title": "Terrain Palette"
+        "Title": "Terrain Palette",
+        "PaintBucket": "Paint Bucket Mode"
       },
       "REALMSELECTOR": {
         "Title": "Realm Palette",
         "IncomeReport": "Income Report"
+      },
+      "PAINTBUCKET": {
+        "ConfirmTitle": "Confirm Paint Bucket",
+        "ConfirmMessage": "This will change {hexCount} hex(es) from {fromTerrain} to {toTerrain}, starting from hex {startHex}. Continue?",
+        "PreviewNote": "Affected hexes are highlighted on the map in the target color.",
+        "Confirm": "Confirm",
+        "Cancel": "Cancel"
       },
       "REMOVE": {
         "Title": "Remove Chex",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -67,11 +67,19 @@
         "PickIconTT": "Otwórz przeglądarkę plików, aby wybrać obraz"
       },
       "TERRAINSELECTOR": {
-        "Title": "Paleta terenu"
+        "Title": "Paleta terenu",
+        "PaintBucket": "Tryb wiadra z farbą"
       },
       "REALMSELECTOR": {
         "Title": "Paleta krain",
         "IncomeReport": "Raport o przychodach"
+      },
+      "PAINTBUCKET": {
+        "ConfirmTitle": "Potwierdź wiadro z farbą",
+        "ConfirmMessage": "Spowoduje to zmianę {hexCount} heks(ów) z {fromTerrain} na {toTerrain}, zaczynając od heksu {startHex}. Kontynuować?",
+        "PreviewNote": "Dotknięte heksy są podświetlone na mapie w kolorze docelowym.",
+        "Confirm": "Potwierdź",
+        "Cancel": "Anuluj"
       },
       "REMOVE": {
         "Title": "Usuń Chex",

--- a/scripts/paint-bucket-confirm.mjs
+++ b/scripts/paint-bucket-confirm.mjs
@@ -1,0 +1,86 @@
+import * as C from "./const.mjs";
+import ChexData from "./chex-data.mjs";
+
+/**
+ * Dialog to confirm paint bucket operation
+ */
+export default class PaintBucketConfirm extends FormApplication {
+  constructor(startHex, targetTerrain, affectedHexes) {
+    super();
+    this.startHex = startHex;
+    this.targetTerrain = targetTerrain;
+    this.affectedHexes = affectedHexes;
+  }
+  
+  static formId = "chex-paintBucketConfirm";
+
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      id: PaintBucketConfirm.formId,
+      classes: [chex.CSS_CLASS],
+      template: "modules/pf2e-chex/templates/chex-paint-bucket-confirm.hbs",
+      width: 320,
+      height: "auto",
+      popOut: true,
+      closeOnSubmit: true
+    });
+  }
+
+  get title() {
+    return game.i18n.localize("CHEX.PAINTBUCKET.ConfirmTitle");
+  }
+
+  startHex;
+  targetTerrain;
+  affectedHexes;
+
+  async _render(force, options) {
+    return super._render(force, options);
+  }
+
+  async close(options) {
+    await super.close(options);
+  }
+
+  async getData(options) {
+    const fromTerrainInfo = chex.terrains[this.startHex.hexData.terrain];
+    const toTerrainInfo = chex.terrains[this.targetTerrain];
+    
+    return Object.assign(await super.getData(options), {
+      hexCount: this.affectedHexes.length,
+      fromTerrain: fromTerrainInfo?.label || C.FALLBACK_LABEL,
+      toTerrain: toTerrainInfo?.label || C.FALLBACK_LABEL,
+      startHex: this.startHex.toString()
+    });
+  }
+
+  activateListeners(html) {
+    super.activateListeners(html);
+    html.on("click", "[data-action]", this.#onClickAction.bind(this));
+  }
+
+  async #onClickAction(event) {
+    event.preventDefault();
+    const control = event.currentTarget;
+    const action = control.dataset.action;
+    
+    if (action === "confirm") {
+      await this.#executePaintBucket();
+    }
+    // For cancel or any other action, just close
+    this.close();
+  }
+
+  async #executePaintBucket() {
+    const patches = this.affectedHexes.reduce((result, hex) => {
+      const key = ChexData.getKey(hex.offset);
+      result.hexes[key] = {
+        terrain: this.targetTerrain,
+        travel: chex.terrains[this.targetTerrain].travel
+      };
+      return result;
+    }, { hexes: {} });
+
+    await canvas.scene.setFlag(C.MODULE_ID, C.CHEX_DATA_KEY, patches);
+  }
+}

--- a/scripts/terrain-palette.mjs
+++ b/scripts/terrain-palette.mjs
@@ -9,7 +9,7 @@ export default class TerrainPalette extends FormApplication {
       width: 240,
       height: "auto",
       popOut: true,
-      closeOnSubmit: true
+      closeOnSubmit: false
     });
   }
 
@@ -18,6 +18,7 @@ export default class TerrainPalette extends FormApplication {
   }
 
   activeTerrainTool = null;
+  paintBucketMode = false;
 
   async _render(force, options) {
     chex.terrainSelector = this;
@@ -31,14 +32,20 @@ export default class TerrainPalette extends FormApplication {
 
   async getData(options) {
     return Object.assign(await super.getData(options), {
-      terrains: chex.terrains
+      terrains: chex.terrains,
+      paintBucketMode: this.paintBucketMode
     });
   }
 
   activateListeners(html) {
       super.activateListeners(html);
       html.on("click", "[data-action]", this.#onClickAction.bind(this));
+      html.on("change", "#paint-bucket-checkbox", this.#onPaintBucketToggle.bind(this));
     }
+
+  #onPaintBucketToggle(event) {
+    this.paintBucketMode = event.target.checked;
+  }
 
   async #onClickAction(event) {
     event.preventDefault();
@@ -47,9 +54,9 @@ export default class TerrainPalette extends FormApplication {
     this.activeTerrainTool = action;
 
     const form = document.getElementById(TerrainPalette.formId);
-    const buttons = form.querySelectorAll('button');
+    const buttons = form.querySelectorAll('button[data-action]');
     buttons.forEach(element => {
-      if (element.id === action) {
+      if (element.dataset.action === action) {
         element.classList.add("active");
       }
       else {

--- a/styles/chex.css
+++ b/styles/chex.css
@@ -139,6 +139,34 @@
 
 .chex-button-row {
   display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.chex-terrain-selector-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chex-paint-bucket-option {
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  border: 1px solid var(--color-border-light-tertiary);
+}
+
+.chex-paint-bucket-option label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.chex-paint-bucket-option input[type="checkbox"] {
+  margin: 0;
 }
 
 .chex-terrain-selector {
@@ -161,4 +189,12 @@
 
 .chex-realm-select {
   width: 100%;
+}
+
+.chex-preview-note {
+  font-size: 11px;
+  color: #666;
+  font-style: italic;
+  margin: 8px 0;
+  text-align: center;
 }

--- a/templates/chex-paint-bucket-confirm.hbs
+++ b/templates/chex-paint-bucket-confirm.hbs
@@ -1,0 +1,12 @@
+<div>
+    <p>
+        {{localize "CHEX.PAINTBUCKET.ConfirmMessage" hexCount=hexCount fromTerrain=fromTerrain toTerrain=toTerrain startHex=startHex}}
+    </p>
+    <p class="chex-preview-note">
+        {{localize "CHEX.PAINTBUCKET.PreviewNote"}}
+    </p>
+    <div class="chex-button-row">
+        <button data-action="confirm">{{localize "CHEX.PAINTBUCKET.Confirm"}}</button>
+        <button type="button" data-action="cancel">{{localize "CHEX.PAINTBUCKET.Cancel"}}</button>
+    </div>
+</div>

--- a/templates/chex-realm-selector.hbs
+++ b/templates/chex-realm-selector.hbs
@@ -1,8 +1,13 @@
-<div>
-    <select class="chex-realm-select" id="chex-realm-select" name="realms">
-        {{selectOptions realms valueAttr="id" labelAttr="label" blank=""}}
-    </select>
-    <button data-action="report">
-        {{localize "CHEX.REALMSELECTOR.IncomeReport"}}
-    </button>
+<div class="chex-terrain-selector-container">
+    <div class="chex-paint-bucket-option">
+        <label>
+            <input type="checkbox" id="paint-bucket-checkbox" {{checked paintBucketMode}}>
+            {{localize "CHEX.TERRAINSELECTOR.PaintBucket"}}
+        </label>
+    </div>
+    <div class="chex-terrain-selector">
+        {{#each terrains}}
+            <button id="{{id}}" data-tooltip="{{label}}" data-action="{{id}}"> <i class="{{toolIcon}}"></i></button>
+        {{/each}}
+    </div>
 </div>

--- a/templates/chex-realm-selector.hbs
+++ b/templates/chex-realm-selector.hbs
@@ -1,13 +1,8 @@
-<div class="chex-terrain-selector-container">
-    <div class="chex-paint-bucket-option">
-        <label>
-            <input type="checkbox" id="paint-bucket-checkbox" {{checked paintBucketMode}}>
-            {{localize "CHEX.TERRAINSELECTOR.PaintBucket"}}
-        </label>
-    </div>
-    <div class="chex-terrain-selector">
-        {{#each terrains}}
-            <button id="{{id}}" data-tooltip="{{label}}" data-action="{{id}}"> <i class="{{toolIcon}}"></i></button>
-        {{/each}}
-    </div>
+<div>
+    <select class="chex-realm-select" id="chex-realm-select" name="realms">
+        {{selectOptions realms valueAttr="id" labelAttr="label" blank=""}}
+    </select>
+    <button data-action="report">
+        {{localize "CHEX.REALMSELECTOR.IncomeReport"}}
+    </button>
 </div>

--- a/templates/chex-terrain-selector.hbs
+++ b/templates/chex-terrain-selector.hbs
@@ -1,5 +1,13 @@
-<div class="chex-terrain-selector">
-    {{#each terrains}}
-        <button id="{{id}}" data-tooltip="{{label}}" data-action="{{id}}"> <i class="{{toolIcon}}"> </i></button>
-    {{/each}}
+<div class="chex-terrain-selector-container">
+    <div class="chex-paint-bucket-option">
+        <label>
+            <input type="checkbox" id="paint-bucket-checkbox" {{checked paintBucketMode}}>
+            {{localize "CHEX.TERRAINSELECTOR.PaintBucket"}}
+        </label>
+    </div>
+    <div class="chex-terrain-selector">
+        {{#each terrains}}
+            <button id="{{id}}" data-tooltip="{{label}}" data-action="{{id}}"> <i class="{{toolIcon}}"></i></button>
+        {{/each}}
+    </div>
 </div>


### PR DESCRIPTION
Loreq's comment on their merge request:

> I modified this module so that I can handle my extremely large Hex Map. Hopefully this helps, I don't think you need to go the particle route or worry about a full rewrite. I used ChatGPT for a lot of the grunt work, then combed through the MANY flaws.
> 
> - Introduce _graphicsByType Map to cache PIXI.Graphics per layer/type with a fingerprint.
> - Only one layer visible at a time; switching modes hides others automatically.
> - Consolidate hex grouping logic into #getHexGroups(layerType).
> - Add #computeLayerFingerprint to detect changes and avoid unnecessary redraws.
> - Draw hex groups asynchronously using requestIdleCallback for large maps.
> - Remove separate #drawTerrain, #drawRealms, and #drawTravel methods; replaced by unified async drawing logic.
> - Borders are now drawn dynamically in #drawHexGroup
> Benefits:
> 
> - Fewer redraws, improved performance on large maps.
> - Smooth mode switching without freezing.
> - Easier to extend for new layer types.
> EDIT: Also added a paint bucket to the module, it was a needed QOL upgrade.